### PR TITLE
feat: Fifty/fifty, Resetroles

### DIFF
--- a/app/participant/page.tsx
+++ b/app/participant/page.tsx
@@ -18,6 +18,7 @@ export default function ParticipantPage() {
     questionsAnswered,
     currentLevel,
     updateGameState,
+    removedOptions
   } = useGameStore();
 
   // State to show feedback messages
@@ -46,7 +47,9 @@ export default function ParticipantPage() {
         score: data.score,
         questionsAnswered: data.questionsAnswered,
         currentLevel: data.currentLevel,
-        failedLevels: data.failedLevels || []
+        failedLevels: data.failedLevels || [],
+        removedOptions: data.removedOptions || [],
+        fiftyFiftyUsed: data.fiftyFiftyUsed || false
       });
 
       if (data.gameEnded) {
@@ -69,11 +72,18 @@ export default function ParticipantPage() {
       setMessage('Connection error. Please refresh the page.');
     };
 
+    const handleResetRoles = () => {
+      console.log('Received resetRoles event, redirecting to home page');
+      // Redirect to home page
+      window.location.href = '/';
+    };
+
     // Set up event listeners
     socket.on('gameState', handleGameState);
     socket.on('connect', handleConnect);
     socket.on('disconnect', handleDisconnect);
     socket.on('connect_error', handleConnectError);
+    socket.on('resetRoles', handleResetRoles);
 
     // Cleanup listeners on unmount
     return () => {
@@ -81,6 +91,7 @@ export default function ParticipantPage() {
       socket.off('connect', handleConnect);
       socket.off('disconnect', handleDisconnect);
       socket.off('connect_error', handleConnectError);
+      socket.off('resetRoles', handleResetRoles);
     };
   }, [socket, updateGameState]);
 
@@ -133,6 +144,7 @@ export default function ParticipantPage() {
                 revealAnswer={revealAnswer}
                 onSelectOption={() => {}} // Participant cannot select options
                 disabled={true} // Always disabled for participant
+                removedOptions={removedOptions}
               />
               
               {gameEnded && (

--- a/components/GameControls.tsx
+++ b/components/GameControls.tsx
@@ -11,8 +11,11 @@ interface GameControlsProps {
   onNextQuestion: () => void;
   onResetGame: () => void;
   onClearState: () => void;
+  onResetRoles: () => void;
+  onFiftyFifty: () => void;
   revealAnswer: boolean;
   gameEnded: boolean;
+  fiftyFiftyUsed: boolean;
 }
 
 export const GameControls: React.FC<GameControlsProps> = ({
@@ -23,8 +26,11 @@ export const GameControls: React.FC<GameControlsProps> = ({
   onNextQuestion,
   onResetGame,
   onClearState,
+  onResetRoles,
+  onFiftyFifty,
   revealAnswer,
-  gameEnded
+  gameEnded,
+  fiftyFiftyUsed
 }) => {
   return (
     <div className="bg-gradient-to-br from-gray-900 to-gray-800 p-6 rounded-lg shadow-lg">
@@ -55,6 +61,21 @@ export const GameControls: React.FC<GameControlsProps> = ({
                 className="bg-gradient-to-r from-red-500 to-red-600 hover:from-red-600 hover:to-red-700 text-white font-bold py-2 px-4 rounded-md transition-all duration-300 shadow-md"
               >
                 Clear All State
+              </button>
+
+              <button
+                onClick={onResetRoles}
+                className="bg-gradient-to-r from-purple-500 to-purple-600 hover:from-purple-600 hover:to-purple-700 text-white font-bold py-2 px-4 rounded-md transition-all duration-300 shadow-md"
+              >
+                Reset Roles
+              </button>
+
+              <button
+                onClick={onFiftyFifty}
+                disabled={!currentQuestion || fiftyFiftyUsed || revealAnswer}
+                className="bg-gradient-to-r from-amber-500 to-amber-600 hover:from-amber-600 hover:to-amber-700 text-white font-bold py-2 px-4 rounded-md transition-all duration-300 shadow-md disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                50/50
               </button>
             </div>
             

--- a/components/OptionButton.tsx
+++ b/components/OptionButton.tsx
@@ -11,6 +11,7 @@ interface OptionButtonProps {
   revealAnswer: boolean;
   onSelect: (optionId: string) => void;
   disabled?: boolean;
+  isRemoved?: boolean;
 }
 
 export const OptionButton: React.FC<OptionButtonProps> = ({
@@ -19,7 +20,8 @@ export const OptionButton: React.FC<OptionButtonProps> = ({
   isCorrect,
   revealAnswer,
   onSelect,
-  disabled = false
+  disabled = false,
+  isRemoved = false
 }) => {
   const getButtonClasses = () => {
     // Default styles
@@ -35,6 +37,9 @@ export const OptionButton: React.FC<OptionButtonProps> = ({
       if (isSelected) {
         // Selected but answer not revealed yet
         classes += ' bg-blue-600 text-white shadow-lg';
+      } else if (isRemoved) {
+        // Removed option
+        classes += ' bg-gray-800 text-gray-500 opacity-50 cursor-not-allowed';
       } else {
         // Not selected and answer not revealed
         classes += ' bg-gradient-to-r from-blue-900 to-indigo-900 text-white/90';
@@ -47,6 +52,9 @@ export const OptionButton: React.FC<OptionButtonProps> = ({
       } else if (isSelected && !isCorrect) {
         // Selected wrong answer
         classes += ' bg-red-600 text-white shadow-md';
+      } else if (isRemoved) {
+        // Removed option
+        classes += ' bg-gray-800 text-gray-500 opacity-50 cursor-not-allowed';
       } else {
         // Other options
         classes += ' bg-blue-900 text-white/70 opacity-80';

--- a/components/QuestionDisplay.tsx
+++ b/components/QuestionDisplay.tsx
@@ -13,6 +13,7 @@ interface QuestionDisplayProps {
   onSelectOption: (optionId: string) => void;
   disabled?: boolean;
   showAnswer?: boolean;
+  removedOptions?: string[];
 }
 
 export const QuestionDisplay: React.FC<QuestionDisplayProps> = ({
@@ -21,7 +22,8 @@ export const QuestionDisplay: React.FC<QuestionDisplayProps> = ({
   revealAnswer,
   onSelectOption,
   disabled = false,
-  showAnswer = false
+  showAnswer = false,
+  removedOptions = []
 }) => {
   if (!question) {
     return (
@@ -46,17 +48,21 @@ export const QuestionDisplay: React.FC<QuestionDisplayProps> = ({
         </h2>
         
         <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
-          {question.options.map((option) => (
-            <OptionButton
-              key={option.id}
-              option={option}
-              isSelected={selectedOption === option.id}
-              isCorrect={option.id === question.correctOption}
-              revealAnswer={revealAnswer}
-              onSelect={onSelectOption}
-              disabled={disabled}
-            />
-          ))}
+          {question.options.map((option) => {
+            const isRemoved = removedOptions.includes(option.id);
+            return (
+              <OptionButton
+                key={option.id}
+                option={option}
+                isSelected={selectedOption === option.id}
+                isCorrect={option.id === question.correctOption}
+                revealAnswer={revealAnswer}
+                onSelect={onSelectOption}
+                disabled={disabled || isRemoved}
+                isRemoved={isRemoved}
+              />
+            );
+          })}
         </div>
         
         {showAnswer && (

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -9,7 +9,12 @@ export const useSocket = () => {
 
   useEffect(() => {
     // Initialize socket connection
-    const socketInstance = io('https://luck-onyx-sprite.glitch.me/');
+    const socketInstance = io('http://localhost:3001', {
+      transports: ['websocket'],
+      reconnection: true,
+      reconnectionAttempts: 5,
+      reconnectionDelay: 1000
+    });
 
     socketInstance.on('connect', () => {
       console.log('Connected to server');

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -22,4 +22,6 @@ export interface GameState {
   questionsAnswered: number;
   currentLevel: number;
   failedLevels: number[];
+  fiftyFiftyUsed: boolean;
+  removedOptions: string[];
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "server": "ts-node server/server.ts"
+    "server": "ts-node server.js"
   },
   "dependencies": {
     "clsx": "^2.1.1",


### PR DESCRIPTION
# Feature: 50/50 Lifeline and Reset Roles

## Overview
This PR adds two new features to our "Who Wants to Be a Millionaire" game:

1. **50/50 Lifeline** - Allows presenters to remove two incorrect options from the current question, making it easier for contestants.
2. **Reset Roles** - Provides a way to reset role assignments and redirect all users back to the home page.

## Changes

### 50/50 Lifeline
- Added state management for tracking removed options and whether the 50/50 lifeline has been used
- Updated UI to display a 50/50 button in the presenter controls
- Implemented logic to randomly select and remove two incorrect answer options
- Added visual styling for removed options (grayed out and disabled)
- Synchronized 50/50 state between server and clients

### Reset Roles
- Added a "Reset Roles" button to the presenter interface
- Implemented event handling for role reset on both server and client
- Added logic to redirect users to home page when roles are reset

### Other Improvements
- Updated socket configuration for better connection reliability
- Fixed server path references to question data
- Improved state management during game progression
- Migrated from server.ts to server.js for simpler execution

## Testing Instructions
1. **50/50 Feature**: 
   - Start a game as presenter
   - Press the 50/50 button during a question
   - Verify that two incorrect options are removed
   - Verify that the 50/50 state resets when moving to the next question

2. **Reset Roles**:
   - Connect with both presenter and participant
   - Press "Reset Roles" button from presenter view
   - Verify that both users are redirected to the home page
